### PR TITLE
Build .deb file for multiple linux distributions with Docker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build
+/ubuntu*
+/debian*

--- a/packaging/build_all_debs
+++ b/packaging/build_all_debs
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Builds the libsxg deb packages for multiple debian family OS with Docker.
+# This script must be run at the root directory of the libsxg source tree.
+# Generated deb packages will put in the directory with the same name of
+# Dockerfiles.
+
+set -ex
+readonly DEB_DOCKER="packaging/dockerfiles/deb.dockerfile"
+readonly DISTROS=(
+  debian:buster-slim
+  debian:stretch-slim
+  ubuntu:disco
+  ubuntu:bionic
+)
+
+for distro in ${DISTROS[@]}; do
+  echo "Target: ${distro}"
+  image_tag="${distro}-libsxg"
+  docker build --build-arg base_image=${distro} -t "${image_tag}" -f "${DEB_DOCKER}" .
+  mkdir -p "${distro}"
+  docker run --rm \
+    --mount "type=bind,source=${PWD}/${distro},target=/libsxg/docker_output" \
+    "${image_tag}"
+  echo "Wrote deb file in ${distro}."
+done

--- a/packaging/dockerfiles/deb.dockerfile
+++ b/packaging/dockerfiles/deb.dockerfile
@@ -1,0 +1,21 @@
+ARG base_image
+FROM ${base_image}
+
+LABEL maintainer "Hiroki Kumazaki <kumagi@google.com>"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends -q \
+                    build-essential \
+                    cmake \
+                    debhelper \
+                    devscripts \
+                    fakeroot \
+                    git \
+                    libssl-dev \
+                    lsb-release && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD . /libsxg
+WORKDIR /libsxg
+
+ENTRYPOINT ["packaging/build_deb", "docker_output"]


### PR DESCRIPTION
Automatically generate .deb files for 
- `debian-buster` (Debian 10)
- `debian-stretch` (Debian 9)
- `ubuntu-disco` (Ubuntu 19.04)
- `ubuntu-bionic` (Ubuntu 18.04 LTS)
Patterns.
