### PR TITLE
OpenSSL 1.1.1 is enough for build

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,7 +10,7 @@ Package: libsxg-dev
 Section: libdevel
 Architecture: any
 Multi-Arch: same
-Depends: libssl-dev (>=1.1.1c), ${misc:Depends}
+Depends: libssl-dev (>=1.1.1), ${misc:Depends}
 Description: Signed HTTP Exchange library.
  Signed HTTP Exchange (SXG) is file format which contains an HTTP exchange
  (request and response) signed by a publisher's origin.


### PR DESCRIPTION
OpenSSL 1.1.1c is current default version of Debian 10 (which is my normal environment).
But building and installing libsxg into other systems, 1.1.1c is too latest (e.g. Ubuntu 18.04LTS uses OpenSSL 1.1.1).
Downgrade dependency version will enable libsxg to install in more environments.