### PR TITLE
Prefer casting to const data, not const pointer

### DIFF
--- a/tests/sxg_codec_test.cc
+++ b/tests/sxg_codec_test.cc
@@ -33,7 +33,7 @@ sxg_buffer_t StringToBuffer(const char* src) {
 }
 
 std::string BufferToString(const sxg_buffer_t& buf) {
-  return std::string(reinterpret_cast<char* const>(buf.data), buf.size);
+  return std::string(reinterpret_cast<const char*>(buf.data), buf.size);
 }
 
 TEST(SxgCodecTest, Sha256) {


### PR DESCRIPTION
Supresses the following warning:

type qualifiers ignored on cast result type [-Wignored-qualifiers]