### PR TITLE
Correct typos in docs

### DIFF
--- a/docs/gensxg.md
+++ b/docs/gensxg.md
@@ -19,7 +19,7 @@ $ gensxg -url https://example.com \
 Calculate integrity hash value of some file.
 
 ```bash
-$ gensxg -ingegrity \
+$ gensxg -integrity \
          -content ./logo.png
          -contentType image/png
     > logo-integrity

--- a/docs/sxg_buffer.md
+++ b/docs/sxg_buffer.md
@@ -263,14 +263,14 @@ sxg_buffer_release(&world);
 
 ### bool sxg\_write\_int(uint64\_t num, int nbytes, sxg\_buffer\_t\* target)
 
-Appends an integer in big-endian format with byte syze `nbytes`.
+Appends an integer in big-endian format with byte size `nbytes`.
 nbytes must be in the range from 1 to 8.
 
 #### Arguments
 
 - `num` : Number to write.
 - `nbytes` : Length of big-endian encoded number to write in bytes.
-- `trarget` : Buffer to be modified.
+- `target` : Buffer to be modified.
 
 #### Returns.
 

--- a/docs/sxg_generate.md
+++ b/docs/sxg_generate.md
@@ -10,7 +10,7 @@ Writes SXG payload to dst.
 
 #### Arguments
 
-- `fallback_url`: An URL which this SXG reporesents for.
+- `fallback_url`: An URL which this SXG represents for.
 - `signers`: Signers list to embed signatures to SXG.
 - `resp`: Internal HTTP response header and body.
 - `dst`: A buffer to store the result SXG.

--- a/docs/sxg_signer_list.md
+++ b/docs/sxg_signer_list.md
@@ -122,7 +122,7 @@ Copies the string parameters and increments the reference count of `private_key`
 - `expires` : Unix time of SXG expiration time.
 - `validity_url` : Validity URL to be embedded into SXG. Must be null terminated. Will be deep copied.
 - `private_key` : ECDSA private key to be used for generating signature. Reference count will be incremented.
-- `public_key` : X509 certificate correspoindings to the `private_key`. Reference count will be incremented.
+- `public_key` : X509 certificate corresponding to the `private_key`. Reference count will be incremented.
 - `certificate_url` : URL for distributing CBOR file of the public_key. Will be deep copied.
 - `target` : Signer list to be modified.
 


### PR DESCRIPTION
Found via `ispell`.