### PR TITLE
Add test common library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ install (
 ########################################
 if (NOT SKIP_TEST)
   enable_testing ()
+
   file (COPY tests/testdata DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
   ExternalProject_Add(
@@ -145,52 +146,59 @@ if (NOT SKIP_TEST)
       "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
   )
   set (GTEST_INCLUDE ${PROJECT_BINARY_DIR}/third_party/gtest/googletest/include)
+
+  add_library(test_util
+    SHARED
+    tests/test_util.cc)
+  target_include_directories(
+    test_util
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/include
+      ${GTEST_INCLUDE}
+  )
+  add_dependencies (test_util sxg libgtest libgtest_main gtest)
+  target_link_libraries (
+    test_util
+    INTERFACE
+      libgtest
+      libgtest_main
+      pthread
+      sxg
+      ${OPENSSL_LIBRARIES}
+  )
 endif ()
 
-function (add_plain_test test_name)
-  set (target_name "${test_name}")
+macro (add_test_macro target_name test_name)
   add_executable (${target_name} tests/${test_name}.cc)
   add_test(
     NAME ${target_name}
     COMMAND ${target_name}
   )
-  add_dependencies (${target_name} sxg libgtest libgtest_main gtest)
-  target_link_libraries (${target_name} sxg libgtest libgtest_main pthread)
+  add_dependencies (${target_name} libgtest libgtest_main gtest sxg test_util)
+  target_link_libraries (
+    ${target_name}
+    PRIVATE
+      libgtest
+      libgtest_main
+      pthread
+      sxg
+      test_util
+      ${OPENSSL_LIBRARIES})
   target_include_directories(
     ${target_name}
     PRIVATE
       ${PROJECT_SOURCE_DIR}/include
       ${GTEST_INCLUDE}
   )
+endmacro ()
+
+function (add_plain_test test_name)
+  add_test_macro (${test_name} ${test_name})
 endfunction ()
 
 set (SANITIZER_OPTIONS "-fsanitize=address,leak,undefined")
 function (add_sanitizer_test test_name)
-  set (target_name "${test_name}_sanitizer")
-  add_executable (${target_name} tests/${test_name}.cc)
-  target_compile_options(
-    ${target_name}
-    PRIVATE
-      ${SANITIZER_OPTIONS}
-  )
-  target_link_options(
-    ${target_name}
-    PRIVATE
-      ${SANITIZER_OPTIONS}
-  )
-
-  add_test(
-    NAME ${target_name}
-    COMMAND ${target_name}
-  )
-  add_dependencies (${target_name} sxg libgtest libgtest_main gtest)
-  target_link_libraries (${target_name} sxg libgtest libgtest_main pthread)
-  target_include_directories(
-    ${target_name}
-    PRIVATE
-      ${PROJECT_SOURCE_DIR}/include
-      ${GTEST_INCLUDE}
-  )
+  add_test_macro ("${test_name}_sanitizer" ${test_name})
 endfunction ()
 
 function (configure_test test_name)
@@ -200,15 +208,15 @@ function (configure_test test_name)
 endfunction ()
 
 if (NOT SKIP_TEST)
+  configure_test (nfail_malloc_test)
   configure_test (sxg_buffer_test)
   configure_test (sxg_codec_test)
+  configure_test (sxg_encoded_response_test)
+  configure_test (sxg_generate_test)
   configure_test (sxg_header_test)
   configure_test (sxg_sig_test)
-  configure_test (sxg_encoded_response_test)
   configure_test (sxg_signer_list_test)
   configure_test (toplevel_test)
-  configure_test (sxg_generate_test)
-  configure_test (nfail_malloc_test)
 endif ()
 
 

--- a/tests/nfail_malloc_test.cc
+++ b/tests/nfail_malloc_test.cc
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include "libsxg.h"
+#include "test_util.h"
 
 namespace {
 
@@ -82,18 +83,10 @@ TEST_F(FailAtNTest, GenerateSxg) {
 
   RunWithoutAllocationLimit([&]() {
     // Prepare keys.
-    FILE* keyfile = fopen("testdata/priv256.key", "r");
-    ASSERT_NE(nullptr, keyfile);
-    priv_key = PEM_read_PrivateKey(keyfile, nullptr, nullptr, nullptr);
-    fclose(keyfile);
+    priv_key = sxg_test::LoadPrivateKey("testdata/priv256.key");
     ASSERT_NE(nullptr, priv_key);
 
-    FILE* certfile = fopen("testdata/cert256.pem", "r");
-    ASSERT_NE(nullptr, certfile);
-
-    char passwd[] = "";
-    cert = PEM_read_X509(certfile, 0, 0, passwd);
-    fclose(certfile);
+    cert = sxg_test::LoadX509Cert("testdata/cert256.pem");
     ASSERT_NE(nullptr, cert);
   });
 
@@ -114,7 +107,7 @@ TEST_F(FailAtNTest, GenerateSxg) {
 
     success =
         success && sxg_write_string(
-            "<!DOCTYPE html><html><body>Hello Sxg!</body></html>\n",
+                       "<!DOCTYPE html><html><body>Hello Sxg!</body></html>\n",
                        &content.payload);
 
     // Encode contents.

--- a/tests/sxg_buffer_test.cc
+++ b/tests/sxg_buffer_test.cc
@@ -13,17 +13,17 @@
 // limitations under the License.
 //
 ///////////////////////////////////////////////////////////////////////////////
+#include "libsxg/sxg_buffer.h"
 
 #include <string>
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
-#include "libsxg/sxg_buffer.h"
 #include "test_util.h"
 
 namespace {
 
-using sxg_test::BufferToString;
+using ::sxg_test::BufferToString;
 
 TEST(SxgBufferTest, InitializeEmpty) {
   sxg_buffer_t buf = sxg_empty_buffer();
@@ -218,8 +218,7 @@ TEST(SxgBufferTest, BufferCopy) {
   EXPECT_TRUE(sxg_buffer_copy(&buf1, &buf2));
   sxg_write_string(" world.", &buf1);
   EXPECT_EQ("hello world.", BufferToString(buf1));
-  EXPECT_EQ("hello",
-            BufferToString(buf2));  // buf2 has been deeply copied.
+  EXPECT_EQ("hello", BufferToString(buf2));  // buf2 has been deeply copied.
 
   sxg_buffer_release(&buf1);
   sxg_buffer_release(&buf2);

--- a/tests/sxg_buffer_test.cc
+++ b/tests/sxg_buffer_test.cc
@@ -14,20 +14,16 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "libsxg/sxg_buffer.h"
-
 #include <string>
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
+#include "libsxg/sxg_buffer.h"
+#include "test_util.h"
 
 namespace {
 
-std::string BufferToString(const sxg_buffer_t& buf) {
-  // Casting from uint8_t* to char* is legal because we confirmed char to have 8
-  // bits.
-  return std::string(reinterpret_cast<const char*>(buf.data), buf.size);
-}
+using sxg_test::BufferToString;
 
 TEST(SxgBufferTest, InitializeEmpty) {
   sxg_buffer_t buf = sxg_empty_buffer();
@@ -222,7 +218,8 @@ TEST(SxgBufferTest, BufferCopy) {
   EXPECT_TRUE(sxg_buffer_copy(&buf1, &buf2));
   sxg_write_string(" world.", &buf1);
   EXPECT_EQ("hello world.", BufferToString(buf1));
-  EXPECT_EQ("hello", BufferToString(buf2));  // buf2 has been deeply copied.
+  EXPECT_EQ("hello",
+            BufferToString(buf2));  // buf2 has been deeply copied.
 
   sxg_buffer_release(&buf1);
   sxg_buffer_release(&buf2);

--- a/tests/sxg_codec_test.cc
+++ b/tests/sxg_codec_test.cc
@@ -14,27 +14,20 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "libsxg/internal/sxg_codec.h"
-
 #include <openssl/pem.h>
 
 #include <string>
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
+#include "libsxg/internal/sxg_codec.h"
 #include "libsxg/sxg_buffer.h"
+#include "test_util.h"
 
 namespace {
 
-sxg_buffer_t StringToBuffer(const char* src) {
-  sxg_buffer_t buf = sxg_empty_buffer();
-  sxg_write_string(src, &buf);
-  return buf;
-}
-
-std::string BufferToString(const sxg_buffer_t& buf) {
-  return std::string(reinterpret_cast<const char*>(buf.data), buf.size);
-}
+using sxg_test::BufferToString;
+using sxg_test::StringToBuffer;
 
 TEST(SxgCodecTest, Sha256) {
   sxg_buffer_t in = StringToBuffer("foo");
@@ -181,29 +174,9 @@ TEST(SxgCodecTest, MiceMultiChunks) {
   sxg_buffer_release(&input);
 }
 
-static EVP_PKEY* LoadPrivateKey(const char* filepath) {
-  FILE* const keyfile = fopen(filepath, "r");
-  EXPECT_NE(nullptr, keyfile) << "Could not open " << filepath;
-  EVP_PKEY* private_key =
-      PEM_read_PrivateKey(keyfile, nullptr, nullptr, nullptr);
-  fclose(keyfile);
-  return private_key;
-}
-
-static EVP_PKEY* LoadPublicKey(const char* filepath) {
-  FILE* certfile = fopen(filepath, "r");
-  EXPECT_NE(nullptr, certfile) << "Could not open " << filepath;
-  char passwd[] = "";
-  X509* cert = PEM_read_X509(certfile, 0, 0, passwd);
-  fclose(certfile);
-  EVP_PKEY* public_key = X509_extract_key(cert);
-  X509_free(cert);
-  return public_key;
-}
-
 TEST(SxgCodecTest, EvpSign) {
-  EVP_PKEY* private_key = LoadPrivateKey("testdata/priv256.key");
-  EVP_PKEY* public_key = LoadPublicKey("testdata/cert256.pem");
+  EVP_PKEY* private_key = sxg_test::LoadPrivateKey("testdata/priv256.key");
+  EVP_PKEY* public_key = sxg_test::LoadPublicKey("testdata/cert256.pem");
   sxg_buffer_t input = StringToBuffer("aaaa");
   sxg_buffer_t output = sxg_empty_buffer();
 

--- a/tests/sxg_codec_test.cc
+++ b/tests/sxg_codec_test.cc
@@ -14,20 +14,21 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "libsxg/internal/sxg_codec.h"
+
 #include <openssl/pem.h>
 
 #include <string>
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
-#include "libsxg/internal/sxg_codec.h"
 #include "libsxg/sxg_buffer.h"
 #include "test_util.h"
 
 namespace {
 
-using sxg_test::BufferToString;
-using sxg_test::StringToBuffer;
+using ::sxg_test::BufferToString;
+using ::sxg_test::StringToBuffer;
 
 TEST(SxgCodecTest, Sha256) {
   sxg_buffer_t in = StringToBuffer("foo");

--- a/tests/sxg_encoded_response_test.cc
+++ b/tests/sxg_encoded_response_test.cc
@@ -14,15 +14,16 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "libsxg/sxg_encoded_response.h"
+
 #include <string>
 
 #include "gtest/gtest.h"
-#include "libsxg/sxg_encoded_response.h"
 #include "test_util.h"
 
 namespace {
 
-using sxg_test::BufferToString;
+using ::sxg_test::BufferToString;
 
 TEST(SxgEncodedResponse, InitializeAndReleaseEmptyRawResponse) {
   sxg_raw_response_t resp = sxg_empty_raw_response();

--- a/tests/sxg_encoded_response_test.cc
+++ b/tests/sxg_encoded_response_test.cc
@@ -14,13 +14,15 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "libsxg/sxg_encoded_response.h"
-
 #include <string>
 
 #include "gtest/gtest.h"
+#include "libsxg/sxg_encoded_response.h"
+#include "test_util.h"
 
 namespace {
+
+using sxg_test::BufferToString;
 
 TEST(SxgEncodedResponse, InitializeAndReleaseEmptyRawResponse) {
   sxg_raw_response_t resp = sxg_empty_raw_response();
@@ -30,12 +32,6 @@ TEST(SxgEncodedResponse, InitializeAndReleaseEmptyRawResponse) {
 TEST(SxgEncodedResponse, InitializeAndReleaseEmptyEncodedResponse) {
   sxg_encoded_response_t resp = sxg_empty_encoded_response();
   sxg_encoded_response_release(&resp);
-}
-
-std::string BufferToString(const sxg_buffer_t& buf) {
-  // Casting from uint8_t* to char* is legal because we confirmed char to have 8
-  // bits.
-  return std::string(reinterpret_cast<const char*>(buf.data), buf.size);
 }
 
 std::string HeaderFindKey(const sxg_header_t& header, const char* key) {

--- a/tests/sxg_generate_test.cc
+++ b/tests/sxg_generate_test.cc
@@ -14,6 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "libsxg/sxg_generate.h"
+
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 
@@ -21,7 +23,6 @@
 #include <string>
 
 #include "gtest/gtest.h"
-#include "libsxg/sxg_generate.h"
 #include "test_util.h"
 
 class GenerateTest : public ::testing::Test {

--- a/tests/sxg_generate_test.cc
+++ b/tests/sxg_generate_test.cc
@@ -14,8 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "libsxg/sxg_generate.h"
-
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 
@@ -23,41 +21,15 @@
 #include <string>
 
 #include "gtest/gtest.h"
-
-static EVP_PKEY* LoadPrivateKey(const char* filepath) {
-  FILE* const keyfile = fopen(filepath, "r");
-  EXPECT_NE(nullptr, keyfile) << "Could not open " << filepath;
-  EVP_PKEY* private_key =
-      PEM_read_PrivateKey(keyfile, nullptr, nullptr, nullptr);
-  fclose(keyfile);
-  return private_key;
-}
-
-static X509* LoadX509Cert(const char* filepath) {
-  FILE* certfile = fopen(filepath, "r");
-  EXPECT_NE(nullptr, certfile) << "Could not open " << filepath;
-  char passwd[] = "";
-  X509* cert = PEM_read_X509(certfile, 0, 0, passwd);
-  fclose(certfile);
-  return cert;
-}
-
-static EVP_PKEY* LoadEd25519Pubkey(const char* filepath) {
-  FILE* keyfile = fopen(filepath, "r");
-  if (!keyfile) {
-    return nullptr;
-  }
-  EVP_PKEY* public_key = PEM_read_PUBKEY(keyfile, nullptr, nullptr, nullptr);
-  fclose(keyfile);
-  return public_key;
-}
+#include "libsxg/sxg_generate.h"
+#include "test_util.h"
 
 class GenerateTest : public ::testing::Test {
  protected:
   void SetEcdsa256() {
     const size_t now = 1234567890;
-    EVP_PKEY* privkey = LoadPrivateKey("testdata/priv256.key");
-    X509* pubkey = LoadX509Cert("testdata/cert256.pem");
+    EVP_PKEY* privkey = sxg_test::LoadPrivateKey("testdata/priv256.key");
+    X509* pubkey = sxg_test::LoadX509Cert("testdata/cert256.pem");
     EXPECT_TRUE(sxg_add_ecdsa_signer(
         "ecdsa256signer", now, now + 60 * 60 * 24,
         "https://original.example.com/resource.validity.msg", privkey, pubkey,
@@ -68,8 +40,8 @@ class GenerateTest : public ::testing::Test {
 
   void SetEcdsa384() {
     const size_t now = 1234567890;
-    EVP_PKEY* privkey = LoadPrivateKey("testdata/priv384.key");
-    X509* pubkey = LoadX509Cert("testdata/cert384.pem");
+    EVP_PKEY* privkey = sxg_test::LoadPrivateKey("testdata/priv384.key");
+    X509* pubkey = sxg_test::LoadX509Cert("testdata/cert384.pem");
     EXPECT_TRUE(sxg_add_ecdsa_signer(
         "ecdsa384signer", now, now + 60 * 60 * 24,
         "https://original.example.com/resource.validity.msg", privkey, pubkey,
@@ -80,8 +52,8 @@ class GenerateTest : public ::testing::Test {
 
   void SetEd25519() {
     const size_t now = 1234567890;
-    EVP_PKEY* privkey = LoadPrivateKey("testdata/ed25519.key");
-    EVP_PKEY* pubkey = LoadEd25519Pubkey("testdata/ed25519.pubkey");
+    EVP_PKEY* privkey = sxg_test::LoadPrivateKey("testdata/ed25519.key");
+    EVP_PKEY* pubkey = sxg_test::LoadEd25519Pubkey("testdata/ed25519.pubkey");
     EXPECT_TRUE(sxg_add_ed25519_signer(
         "ed25519signer", now, now + 60 * 60 * 24,
         "https://original.example.com/resource.validity.msg", privkey, pubkey,

--- a/tests/sxg_header_test.cc
+++ b/tests/sxg_header_test.cc
@@ -14,23 +14,16 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "libsxg/sxg_header.h"
-
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
 #include "libsxg/internal/sxg_header.h"
+#include "libsxg/sxg_header.h"
+#include "test_util.h"
 
 namespace {
 
-sxg_buffer_t StringToBuffer(const char* src) {
-  sxg_buffer_t buf = sxg_empty_buffer();
-  sxg_write_string(src, &buf);
-  return buf;
-}
-
-std::string BufferToString(const sxg_buffer_t& buf) {
-  return std::string(reinterpret_cast<char* const>(buf.data), buf.size);
-}
+using sxg_test::BufferToString;
+using sxg_test::StringToBuffer;
 
 TEST(SxgHeaderTest, Release) {
   sxg_header_t header = sxg_empty_header();

--- a/tests/sxg_header_test.cc
+++ b/tests/sxg_header_test.cc
@@ -14,16 +14,17 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "libsxg/sxg_header.h"
+
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
 #include "libsxg/internal/sxg_header.h"
-#include "libsxg/sxg_header.h"
 #include "test_util.h"
 
 namespace {
 
-using sxg_test::BufferToString;
-using sxg_test::StringToBuffer;
+using ::sxg_test::BufferToString;
+using ::sxg_test::StringToBuffer;
 
 TEST(SxgHeaderTest, Release) {
   sxg_header_t header = sxg_empty_header();

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -14,12 +14,13 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "libsxg/internal/sxg_sig.h"
+
 #include <cstdio>
 #include <string>
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_codec.h"
-#include "libsxg/internal/sxg_sig.h"
 #include "libsxg/sxg_buffer.h"
 #include "test_util.h"
 

--- a/tests/sxg_signer_list_test.cc
+++ b/tests/sxg_signer_list_test.cc
@@ -14,8 +14,6 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "libsxg/sxg_signer_list.h"
-
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 
@@ -23,35 +21,10 @@
 #include <string>
 
 #include "gtest/gtest.h"
+#include "libsxg/sxg_signer_list.h"
+#include "test_util.h"
 
 namespace {
-
-static EVP_PKEY* LoadPrivateKey(const char* filepath) {
-  FILE* const keyfile = fopen(filepath, "r");
-  EXPECT_NE(nullptr, keyfile) << "Could not open " << filepath;
-
-  EVP_PKEY* private_key =
-      PEM_read_PrivateKey(keyfile, nullptr, nullptr, nullptr);
-  fclose(keyfile);
-  return private_key;
-}
-
-static X509* LoadX509Cert(const char* filepath) {
-  FILE* certfile = fopen(filepath, "r");
-  EXPECT_NE(nullptr, certfile) << "Could not open " << filepath;
-  char passwd = 0;  // as empty string
-  X509* cert = PEM_read_X509(certfile, 0, 0, &passwd);
-  fclose(certfile);
-  return cert;
-}
-
-static EVP_PKEY* LoadEd25519Pubkey(const char* filepath) {
-  FILE* keyfile = fopen(filepath, "r");
-  EXPECT_NE(nullptr, keyfile) << "Could not open " << filepath;
-  EVP_PKEY* public_key = PEM_read_PUBKEY(keyfile, nullptr, nullptr, nullptr);
-  fclose(keyfile);
-  return public_key;
-}
 
 TEST(SingersList, EmptyRelease) {
   sxg_signer_list_t signers = sxg_empty_signer_list();
@@ -61,8 +34,8 @@ TEST(SingersList, EmptyRelease) {
 TEST(SingersList, LoadEcdsa256) {
   sxg_signer_list_t signers = sxg_empty_signer_list();
   const time_t now = time(nullptr);
-  EVP_PKEY* privkey = LoadPrivateKey("testdata/priv256.key");
-  X509* pubkey = LoadX509Cert("testdata/cert256.pem");
+  EVP_PKEY* privkey = sxg_test::LoadPrivateKey("testdata/priv256.key");
+  X509* pubkey = sxg_test::LoadX509Cert("testdata/cert256.pem");
 
   EXPECT_TRUE(sxg_add_ecdsa_signer(
       "ecdsa256signer", now, now + 60 * 60 * 24,
@@ -78,8 +51,8 @@ TEST(SingersList, LoadEcdsa256) {
 TEST(SingersList, LoadEd25519) {
   sxg_signer_list_t signers = sxg_empty_signer_list();
   const size_t now = time(nullptr);
-  EVP_PKEY* privkey = LoadPrivateKey("testdata/ed25519.key");
-  EVP_PKEY* pubkey = LoadEd25519Pubkey("testdata/ed25519.pubkey");
+  EVP_PKEY* privkey = sxg_test::LoadPrivateKey("testdata/ed25519.key");
+  EVP_PKEY* pubkey = sxg_test::LoadEd25519Pubkey("testdata/ed25519.pubkey");
 
   EXPECT_TRUE(sxg_add_ed25519_signer(
       "ed25519signer", now, now + 60 * 60 * 24,

--- a/tests/sxg_signer_list_test.cc
+++ b/tests/sxg_signer_list_test.cc
@@ -14,6 +14,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "libsxg/sxg_signer_list.h"
+
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 
@@ -21,7 +23,6 @@
 #include <string>
 
 #include "gtest/gtest.h"
-#include "libsxg/sxg_signer_list.h"
 #include "test_util.h"
 
 namespace {

--- a/tests/test_util.cc
+++ b/tests/test_util.cc
@@ -1,0 +1,75 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include "gtest/gtest.h"
+#include "libsxg/sxg_buffer.h"
+#include "test_util.h"
+
+namespace sxg_test {
+
+std::string BufferToString(const sxg_buffer_t& buf) {
+  // Casting from uint8_t* to char* is legal because we confirmed char to have 8
+  // bits.
+  return std::string(reinterpret_cast<const char*>(buf.data), buf.size);
+}
+
+sxg_buffer_t StringToBuffer(const char* src) {
+  sxg_buffer_t buf = sxg_empty_buffer();
+  sxg_write_string(src, &buf);
+  return buf;
+}
+
+X509* LoadX509Cert(const std::string& filename) {
+  FILE* const certfile = fopen(filename.c_str(), "r");
+  EXPECT_NE(nullptr, certfile) << "Failed to open privatekey";
+  X509* cert = PEM_read_X509(certfile, 0, 0, NULL);
+  fclose(certfile);
+  return cert;
+}
+
+EVP_PKEY* LoadPrivateKey(const std::string& filepath) {
+  FILE* const keyfile = fopen(filepath.c_str(), "r");
+  EXPECT_NE(nullptr, keyfile) << "Could not open " << filepath;
+  EVP_PKEY* private_key =
+      PEM_read_PrivateKey(keyfile, nullptr, nullptr, nullptr);
+  fclose(keyfile);
+  return private_key;
+}
+
+EVP_PKEY* LoadPublicKey(const std::string& filepath) {
+  FILE* certfile = fopen(filepath.c_str(), "r");
+  EXPECT_NE(nullptr, certfile) << "Could not open " << filepath;
+  char passwd[] = "";
+  X509* cert = PEM_read_X509(certfile, 0, 0, passwd);
+  fclose(certfile);
+  EVP_PKEY* public_key = X509_extract_key(cert);
+  X509_free(cert);
+  return public_key;
+}
+
+EVP_PKEY* LoadEd25519Pubkey(const char* filepath) {
+  FILE* keyfile = fopen(filepath, "r");
+  EXPECT_NE(nullptr, keyfile) << "Could not open " << filepath;
+  EVP_PKEY* public_key = PEM_read_PUBKEY(keyfile, nullptr, nullptr, nullptr);
+  fclose(keyfile);
+  return public_key;
+}
+
+}  // namespace sxg_test

--- a/tests/test_util.cc
+++ b/tests/test_util.cc
@@ -40,7 +40,7 @@ sxg_buffer_t StringToBuffer(const char* src) {
 X509* LoadX509Cert(const std::string& filepath) {
   FILE* const certfile = fopen(filepath.c_str(), "r");
   if (certfile == nullptr) {
-    std::cerr << "Failed to open privatekey";
+    std::cerr << "Could not open certificate from " << filepath;
     abort();
   }
   X509* cert = PEM_read_X509(certfile, nullptr, nullptr, nullptr);
@@ -51,7 +51,7 @@ X509* LoadX509Cert(const std::string& filepath) {
 EVP_PKEY* LoadPrivateKey(const std::string& filepath) {
   FILE* const keyfile = fopen(filepath.c_str(), "r");
   if (keyfile == nullptr) {
-    std::cerr <<  "Could not open " << filepath;
+    std::cerr <<  "Could not open private key from " << filepath;
     abort();
   }
   EVP_PKEY* private_key =
@@ -63,7 +63,7 @@ EVP_PKEY* LoadPrivateKey(const std::string& filepath) {
 EVP_PKEY* LoadPublicKey(const std::string& filepath) {
   X509* cert = LoadX509Cert(filepath);
   if (cert == nullptr) {
-    std::cerr <<  "Could not Load cert from " << filepath;
+    std::cerr <<  "Could not open public key from " << filepath;
     abort();
   }
   EVP_PKEY* public_key = X509_extract_key(cert);
@@ -74,7 +74,7 @@ EVP_PKEY* LoadPublicKey(const std::string& filepath) {
 EVP_PKEY* LoadEd25519Pubkey(const std::string& filepath) {
   FILE* keyfile = fopen(filepath.c_str(), "r");
   if (keyfile == nullptr) {
-    std::cerr <<  "Could not open " << filepath;
+    std::cerr <<  "Could not open Ed25519 public key from " << filepath;
     abort();
   }
   EVP_PKEY* public_key = PEM_read_PUBKEY(keyfile, nullptr, nullptr, nullptr);

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -1,0 +1,36 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include "libsxg/sxg_buffer.h"
+#include <string>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+
+namespace sxg_test {
+
+std::string BufferToString(const sxg_buffer_t& buf);
+
+sxg_buffer_t StringToBuffer(const char* src);
+
+X509* LoadX509Cert(const std::string& filename);
+
+EVP_PKEY* LoadPrivateKey(const std::string& filepath);
+
+EVP_PKEY* LoadPublicKey(const std::string& filepath);
+
+EVP_PKEY* LoadEd25519Pubkey(const char* filepath);
+
+}  // namespace sxg_test

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -25,12 +25,12 @@ std::string BufferToString(const sxg_buffer_t& buf);
 
 sxg_buffer_t StringToBuffer(const char* src);
 
-X509* LoadX509Cert(const std::string& filename);
+X509* LoadX509Cert(const std::string& filepath);
 
 EVP_PKEY* LoadPrivateKey(const std::string& filepath);
 
 EVP_PKEY* LoadPublicKey(const std::string& filepath);
 
-EVP_PKEY* LoadEd25519Pubkey(const char* filepath);
+EVP_PKEY* LoadEd25519Pubkey(const std::string& filepath);
 
 }  // namespace sxg_test

--- a/tests/toplevel_test.cc
+++ b/tests/toplevel_test.cc
@@ -14,26 +14,18 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include <openssl/ssl.h>
 #include <stdbool.h>
 #include <time.h>
 
 #include "gtest/gtest.h"
 #include "libsxg.h"
+#include "test_util.h"
 
 // Almost similar to README.md test.
 TEST(LibSXG, TopLevel) {
   // Load keys.
-  char passwd[] = "";
-  FILE* keyfile = fopen("testdata/priv256.key", "r");
-  ASSERT_NE(nullptr, keyfile) << "Failed to open privatekey";
-  EVP_PKEY* priv_key = PEM_read_PrivateKey(keyfile, nullptr, nullptr, nullptr);
-  fclose(keyfile);
-
-  FILE* certfile = fopen("testdata/cert256.pem", "r");
-  ASSERT_NE(nullptr, certfile) << "Failed to open certificates.";
-  X509* cert = PEM_read_X509(certfile, 0, 0, passwd);
-  fclose(certfile);
+  EVP_PKEY* priv_key = sxg_test::LoadPrivateKey("testdata/priv256.key");
+  X509* cert = sxg_test::LoadX509Cert("testdata/cert256.pem");
 
   // Initialize signers.
   time_t now = time(nullptr);


### PR DESCRIPTION
Move common functions as utility library. 
- `BufferToString`
- `StringToBuffer`
- `LoadX509Cert`
- `LoadPrivateKey`
- `LoadPublicKey`
- `LoadEd25519Pubkey`