### PR TITLE
add missing include header

### DIFF
--- a/src/sxg_header.c
+++ b/src/sxg_header.c
@@ -18,7 +18,9 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <inttypes.h>
 #include <openssl/crypto.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "libsxg/internal/sxg_buffer.h"


### PR DESCRIPTION
- `PRIu64` requires `<inttypes.h>`
- `snprintf` requires `<stdio.h>`