### PR TITLE
add missing header

### DIFF
--- a/src/sxg_signer_list.c
+++ b/src/sxg_signer_list.c
@@ -17,6 +17,8 @@
 #include "libsxg/sxg_signer_list.h"
 
 #include <assert.h>
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
 #include <openssl/x509.h>
 
 #include "libsxg/internal/sxg_buffer.h"


### PR DESCRIPTION
- `OPENSSL_free` requires `#include <openssl/crypto.h>`
- `EVP_PKEY_free` requires `#include <openssl/evp.h>`
dependency should be more verbose.