### PR TITLE
extract and merge the cbor manipulation functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(
   SHARED
     src/sxg_buffer.c
     src/sxg_buffer_debug.c
+    src/sxg_cbor.c
     src/sxg_cert_chain.c
     src/sxg_codec.c
     src/sxg_generate.c
@@ -235,6 +236,7 @@ endfunction ()
 if (RUN_TEST)
   configure_test (nfail_malloc_test)
   configure_test (sxg_buffer_test)
+  configure_test (sxg_cbor_test)
   configure_test (sxg_cert_chain_test)
   configure_test (sxg_codec_test)
   configure_test (sxg_encoded_response_test)

--- a/include/libsxg/internal/sxg_buffer.h
+++ b/include/libsxg/internal/sxg_buffer.h
@@ -34,22 +34,6 @@ bool sxg_ensure_free_capacity_internal(size_t size, size_t desired_margin,
 // range from 1 to 8. Returns true on success.
 bool sxg_write_int(uint64_t num, int nbytes, sxg_buffer_t* target);
 
-// Appends the initial bytes for a utf-8 string (for internal use).
-// Returns true on success.
-bool sxg_write_utf8_cbor_header(uint64_t length, sxg_buffer_t* target);
-
-// Appends utf-8 encoded string to the buffer. `string` must be null terminated.
-// Returns true on success.
-bool sxg_write_utf8string_cbor(const char* string, sxg_buffer_t* target);
-
-// Appends the initial bytes for a byte string (for internal use).
-// Returns true on success.
-bool sxg_write_cbor_header(uint64_t length, sxg_buffer_t* target);
-
-// Appends a byte string encoded in CBOR. Returns true on success.
-bool sxg_write_bytes_cbor(const uint8_t* bytes, size_t length,
-                          sxg_buffer_t* target);
-
 // Prints the content of the buffer to stdout in a hexdump-like format.
 void sxg_buffer_dump(const sxg_buffer_t* target);
 

--- a/include/libsxg/internal/sxg_cbor.h
+++ b/include/libsxg/internal/sxg_cbor.h
@@ -1,0 +1,54 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef LIBSXG_INTERNAL_SXG_CBOR_H_
+#define LIBSXG_INTERNAL_SXG_CBOR_H_
+
+#include "libsxg/sxg_buffer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Appends the initial bytes for a byte string (for internal use).
+// Returns true on success.
+bool sxg_write_bytes_cbor_header(uint64_t length, sxg_buffer_t* target);
+
+// Appends the initial bytes for a utf-8 string (for internal use).
+// Returns true on success.
+bool sxg_write_utf8_cbor_header(uint64_t length, sxg_buffer_t* target);
+
+// Appends the header for a map (visible for testing).
+// Returns true on success.
+bool sxg_write_map_cbor_header(size_t size, sxg_buffer_t* target);
+
+// Appends the initial bytes for a array.
+// Returns true on success.
+bool sxg_write_array_cbor_header(uint64_t length, sxg_buffer_t* target);
+
+// Appends utf-8 encoded string to the buffer. `string` must be null terminated.
+// Returns true on success.
+bool sxg_write_utf8string_cbor(const char* string, sxg_buffer_t* target);
+
+// Appends a byte string encoded in CBOR. Returns true on success.
+bool sxg_write_bytes_cbor(const uint8_t* bytes, size_t length,
+                          sxg_buffer_t* target);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LIBSXG_INTERNAL_SXG_

--- a/include/libsxg/internal/sxg_header.h
+++ b/include/libsxg/internal/sxg_header.h
@@ -26,10 +26,6 @@
 extern "C" {
 #endif
 
-// Appends the header for a map (visible for testing).
-// Returns true on success.
-bool sxg_write_cbor_map_header(size_t size, sxg_buffer_t* target);
-
 // Generates data for SXG's signedHeader. Returns true on success.
 bool sxg_header_serialize_cbor(const sxg_header_t* from, sxg_buffer_t* dst);
 

--- a/src/sxg_buffer.c
+++ b/src/sxg_buffer.c
@@ -111,50 +111,8 @@ bool sxg_write_byte(uint8_t byte, sxg_buffer_t* target) {
   return true;
 }
 
-bool sxg_write_utf8_cbor_header(uint64_t length, sxg_buffer_t* target) {
-  if (length <= 0x17) {
-    return sxg_write_byte(0x60 + length, target);
-  } else if (length <= 0xff) {
-    return sxg_write_byte(0x78, target) && sxg_write_int(length, 1, target);
-  } else if (length <= 0xffff) {
-    return sxg_write_byte(0x79, target) && sxg_write_int(length, 2, target);
-  } else if (length <= 0xffffffffULL) {
-    return sxg_write_byte(0x7a, target) && sxg_write_int(length, 4, target);
-  } else {
-    return sxg_write_byte(0x7b, target) && sxg_write_int(length, 8, target);
-  }
-  return false;
-}
-
-bool sxg_write_utf8string_cbor(const char* string, sxg_buffer_t* target) {
-  size_t length = strlen(string);
-  return sxg_write_utf8_cbor_header(length, target) &&
-         sxg_write_bytes((const uint8_t*)string, length, target);
-}
-
 bool sxg_write_string(const char* string, sxg_buffer_t* target) {
   return sxg_write_bytes((const uint8_t*)string, strlen(string), target);
-}
-
-bool sxg_write_cbor_header(uint64_t length, sxg_buffer_t* target) {
-  if (length <= 0x17) {
-    return sxg_write_byte(0x40 + length, target);
-  } else if (length <= 0xff) {
-    return sxg_write_byte(0x58, target) && sxg_write_int(length, 1, target);
-  } else if (length <= 0xffff) {
-    return sxg_write_byte(0x59, target) && sxg_write_int(length, 2, target);
-  } else if (length <= 0xffffffffULL) {
-    return sxg_write_byte(0x5a, target) && sxg_write_int(length, 4, target);
-  } else {
-    return sxg_write_byte(0x5b, target) && sxg_write_int(length, 8, target);
-  }
-  return false;
-}
-
-bool sxg_write_bytes_cbor(const uint8_t* bytes, size_t length,
-                          sxg_buffer_t* target) {
-  return sxg_write_cbor_header(length, target) &&
-         sxg_write_bytes(bytes, length, target);
 }
 
 bool sxg_write_int(uint64_t num, int nbytes, sxg_buffer_t* target) {

--- a/src/sxg_cbor.c
+++ b/src/sxg_cbor.c
@@ -23,6 +23,7 @@ static bool write_initial_bytes(uint8_t type_offset, uint64_t length,
                                 sxg_buffer_t* target) {
   // https://tools.ietf.org/html/rfc7049#appendix-B
   // It writes cbor header for the type.
+  // In SXG, using smallest type header as possible is required.
   if (length <= 0x17) {
     return sxg_write_byte(type_offset + length, target);
   } else if (length <= 0xff) {

--- a/src/sxg_cbor.c
+++ b/src/sxg_cbor.c
@@ -1,0 +1,69 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include "libsxg/internal/sxg_cbor.h"
+
+#include <string.h>
+#include "libsxg/internal/sxg_buffer.h"
+
+static bool write_initial_bytes(uint8_t type_offset, uint64_t length,
+                                sxg_buffer_t* target) {
+  // https://tools.ietf.org/html/rfc7049#appendix-B
+  // It writes cbor header for the type.
+  if (length <= 0x17) {
+    return sxg_write_byte(type_offset + length, target);
+  } else if (length <= 0xff) {
+    return sxg_write_byte(type_offset + 0x18, target) &&
+           sxg_write_int(length, 1, target);
+  } else if (length <= 0xffff) {
+    return sxg_write_byte(type_offset + 0x19, target) &&
+           sxg_write_int(length, 2, target);
+  } else if (length <= 0xffffffffULL) {
+    return sxg_write_byte(type_offset + 0x1a, target) &&
+           sxg_write_int(length, 4, target);
+  } else {
+    return sxg_write_byte(type_offset + 0x1b, target) &&
+           sxg_write_int(length, 8, target);
+  }
+}
+
+bool sxg_write_bytes_cbor_header(uint64_t length, sxg_buffer_t* target) {
+  return write_initial_bytes(0x40, length, target);
+}
+
+bool sxg_write_utf8_cbor_header(uint64_t length, sxg_buffer_t* target) {
+  return write_initial_bytes(0x60, length, target);
+}
+
+bool sxg_write_map_cbor_header(uint64_t size, sxg_buffer_t* target) {
+  return write_initial_bytes(0xa0, size, target);
+}
+
+bool sxg_write_array_cbor_header(uint64_t length, sxg_buffer_t* target) {
+  return write_initial_bytes(0x80, length, target);
+}
+
+bool sxg_write_utf8string_cbor(const char* string, sxg_buffer_t* target) {
+  size_t length = strlen(string);
+  return sxg_write_utf8_cbor_header(length, target) &&
+         sxg_write_bytes((const uint8_t*)string, length, target);
+}
+
+bool sxg_write_bytes_cbor(const uint8_t* bytes, size_t length,
+                          sxg_buffer_t* target) {
+  return sxg_write_bytes_cbor_header(length, target) &&
+         sxg_write_bytes(bytes, length, target);
+}

--- a/tests/sxg_buffer_test.cc
+++ b/tests/sxg_buffer_test.cc
@@ -19,6 +19,7 @@
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
+#include "libsxg/internal/sxg_cbor.h"
 #include "test_util.h"
 
 namespace {
@@ -163,7 +164,7 @@ TEST(SxgBufferTest, WriteBigEndianInt) {
 
 static std::string HeaderToString(size_t length) {
   sxg_buffer_t buf = sxg_empty_buffer();
-  if (!sxg_write_cbor_header(length, &buf)) {
+  if (!sxg_write_bytes_cbor_header(length, &buf)) {
     return "";
   }
   const std::string header = BufferToString(buf);

--- a/tests/sxg_cbor_test.cc
+++ b/tests/sxg_cbor_test.cc
@@ -1,0 +1,125 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+///////////////////////////////////////////////////////////////////////////////
+#include "libsxg/internal/sxg_cbor.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "libsxg/internal/sxg_buffer.h"
+#include "libsxg/internal/sxg_cbor.h"
+#include "test_util.h"
+
+namespace {
+
+using ::sxg_test::BufferToString;
+
+static std::string HeaderToString(size_t length) {
+  sxg_buffer_t buf = sxg_empty_buffer();
+  if (!sxg_write_bytes_cbor_header(length, &buf)) {
+    return "";
+  }
+  const std::string header = BufferToString(buf);
+  sxg_buffer_release(&buf);
+  return header;
+}
+
+TEST(SxgCborTest, WriteBytesCborHeader) {
+  EXPECT_EQ("\x40", HeaderToString(0));
+  EXPECT_EQ("\x43", HeaderToString(3));
+
+  // 0x17 is the biggest number represented in 1 byte.
+  EXPECT_EQ("\x57", HeaderToString(0x17));
+
+  // 0x18 is the smallest number represented in 2 bytes.
+  EXPECT_EQ("\x58\x18", HeaderToString(0x18));
+  EXPECT_EQ("\x58\xff", HeaderToString(0xff));
+
+  // 0x0100 is represented in 3 bytes.
+  EXPECT_EQ(std::string("\x59\x01\x00", 3), HeaderToString(0x100));
+  EXPECT_EQ("\x59\xd3\xd7", HeaderToString(0xd3d7));
+  EXPECT_EQ("\x59\xff\xff", HeaderToString(0xffff));
+
+  // 0x010000 is represented in 5 bytes.
+  EXPECT_EQ(std::string("\x5a\x00\x01\x00\x00", 5), HeaderToString(0x10000));
+  EXPECT_EQ("\x5a\x12\x34\x56\x78", HeaderToString(0x12345678));
+  EXPECT_EQ("\x5a\xff\xff\xff\xff", HeaderToString(0xffffffffULL));
+
+  // 0x0100000000 is represented in 9 bytes.
+  EXPECT_EQ(std::string("\x5b\x00\x00\x00\x01\x00\x00\x00\x00", 9),
+            HeaderToString(0x100000000));
+  EXPECT_EQ("\x5b\xff\xff\xff\xff\xff\xff\xff\xff",
+            HeaderToString(0xffffffffffffffffULL));
+}
+
+std::string GetMapHeader(size_t length) {
+  sxg_buffer_t buf = sxg_empty_buffer();
+  EXPECT_TRUE(sxg_write_map_cbor_header(length, &buf));
+  const std::string header = BufferToString(buf);
+  sxg_buffer_release(&buf);
+  return header;
+}
+
+TEST(SxgCborTest, CborMapHeader) {
+  EXPECT_EQ("\xa0", GetMapHeader(0));
+  EXPECT_EQ("\xa3", GetMapHeader(3));
+
+  // 0xb7 is the biggest number represented in 1 byte.
+  EXPECT_EQ("\xb7", GetMapHeader(0x17));
+
+  // 0xb8 is the smallest number represented in 2 bytes.
+  EXPECT_EQ("\xb8\x18", GetMapHeader(0x18));
+  EXPECT_EQ("\xb8\xff", GetMapHeader(0xff));
+
+  // 0x0100 is represented in 3 bytes.
+  EXPECT_EQ(std::string("\xb9\x01\x00", 3), GetMapHeader(0x100));
+  EXPECT_EQ("\xb9\xd3\xd7", GetMapHeader(0xd3d7));
+  EXPECT_EQ("\xb9\xff\xff", GetMapHeader(0xffff));
+
+  // 0x010000 is represented in 5 bytes.
+  EXPECT_EQ(std::string("\xba\x00\x01\x00\x00", 5), GetMapHeader(0x10000));
+  EXPECT_EQ("\xba\x12\x34\x56\x78", GetMapHeader(0x12345678));
+  EXPECT_EQ("\xba\xff\xff\xff\xff", GetMapHeader(0xffffffffULL));
+
+  // 0x0100000000 is represented in 9 bytes.
+  EXPECT_EQ(std::string("\xbb\x00\x00\x00\x01\x00\x00\x00\x00", 9),
+            GetMapHeader(0x100000000));
+  EXPECT_EQ("\xbb\xff\xff\xff\xff\xff\xff\xff\xff",
+            GetMapHeader(0xffffffffffffffffULL));
+}
+
+TEST(SxgCborTest, WriteBytesCbor) {
+  sxg_buffer_t buf = sxg_empty_buffer();
+  const uint8_t bytes[4] = {'t', 'e', 's', 't'};
+
+  EXPECT_TRUE(sxg_write_bytes_cbor(bytes, 4, &buf));
+  // "\x44test" means encoded "test".
+  EXPECT_EQ("\x44test", BufferToString(buf));
+
+  sxg_buffer_release(&buf);
+}
+
+TEST(SxgCborTest, WriteUtf8Cbor) {
+  sxg_buffer_t buf = sxg_empty_buffer();
+  const char utf8string[] = u8"📜";
+
+  EXPECT_TRUE(sxg_write_utf8string_cbor(utf8string, &buf));
+  // "\x64\xF0\x9F\x93\x9C" means utf8 encoded "📜".
+  EXPECT_EQ("\x64\xF0\x9F\x93\x9C", BufferToString(buf));
+
+  sxg_buffer_release(&buf);
+}
+
+}  // namespace

--- a/tests/sxg_header_test.cc
+++ b/tests/sxg_header_test.cc
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_buffer.h"
+#include "libsxg/internal/sxg_cbor.h"
 #include "libsxg/internal/sxg_header.h"
 #include "test_util.h"
 
@@ -143,42 +144,6 @@ TEST(SxgHeaderTest, Merge) {
 
   sxg_header_release(&header1);
   sxg_header_release(&header2);
-}
-
-std::string GetMapHeader(size_t length) {
-  sxg_buffer_t buf = sxg_empty_buffer();
-  EXPECT_TRUE(sxg_write_cbor_map_header(length, &buf));
-  const std::string header = BufferToString(buf);
-  sxg_buffer_release(&buf);
-  return header;
-}
-
-TEST(SxgHeaderTest, CborHeader) {
-  EXPECT_EQ("\xa0", GetMapHeader(0));
-  EXPECT_EQ("\xa3", GetMapHeader(3));
-
-  // 0xb7 is the biggest number represented in 1 byte.
-  EXPECT_EQ("\xb7", GetMapHeader(0x17));
-
-  // 0xb8 is the smallest number represented in 2 bytes.
-  EXPECT_EQ("\xb8\x18", GetMapHeader(0x18));
-  EXPECT_EQ("\xb8\xff", GetMapHeader(0xff));
-
-  // 0x0100 is represented in 3 bytes.
-  EXPECT_EQ(std::string("\xb9\x01\x00", 3), GetMapHeader(0x100));
-  EXPECT_EQ("\xb9\xd3\xd7", GetMapHeader(0xd3d7));
-  EXPECT_EQ("\xb9\xff\xff", GetMapHeader(0xffff));
-
-  // 0x010000 is represented in 5 bytes.
-  EXPECT_EQ(std::string("\xba\x00\x01\x00\x00", 5), GetMapHeader(0x10000));
-  EXPECT_EQ("\xba\x12\x34\x56\x78", GetMapHeader(0x12345678));
-  EXPECT_EQ("\xba\xff\xff\xff\xff", GetMapHeader(0xffffffffULL));
-
-  // 0x0100000000 is represented in 9 bytes.
-  EXPECT_EQ(std::string("\xbb\x00\x00\x00\x01\x00\x00\x00\x00", 9),
-            GetMapHeader(0x100000000));
-  EXPECT_EQ("\xbb\xff\xff\xff\xff\xff\xff\xff\xff",
-            GetMapHeader(0xffffffffffffffffULL));
 }
 
 TEST(SxgHeaderTest, SerializeInCbor) {


### PR DESCRIPTION
closes #35 
a basic refactoring.
It includes some name change in internal functions for consistency.