### PR TITLE
use IncludeBlocks: Regroup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 # Run manually to reformat a file:
 # clang-format -i --style=file <file>
-Language:     Cpp
-BasedOnStyle: Google
+Language:      Cpp
+BasedOnStyle:  Google
+IncludeBlocks: Regroup

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -6,4 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checker
-      uses: kumagi/clang-format-action@clang8-check-diff
+      uses: kumagi/clang-format-action@clang9-check-diff

--- a/src/gencertchain.c
+++ b/src/gencertchain.c
@@ -2,16 +2,15 @@
 #include <errno.h>
 #include <getopt.h>
 #include <glob.h>
+#include <openssl/crypto.h>
+#include <openssl/ocsp.h>
+#include <openssl/pem.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-
-#include <openssl/crypto.h>
-#include <openssl/ocsp.h>
-#include <openssl/pem.h>
 
 #include "libsxg.h"
 #include "libsxg/internal/sxg_buffer.h"

--- a/src/gensxg.c
+++ b/src/gensxg.c
@@ -1,14 +1,13 @@
 #define _XOPEN_SOURCE
 #include <errno.h>
 #include <getopt.h>
+#include <openssl/pem.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-
-#include <openssl/pem.h>
 
 #include "libsxg.h"
 

--- a/src/sxg_cbor.c
+++ b/src/sxg_cbor.c
@@ -17,6 +17,7 @@
 #include "libsxg/internal/sxg_cbor.h"
 
 #include <string.h>
+
 #include "libsxg/internal/sxg_buffer.h"
 
 static bool write_initial_bytes(uint8_t type_offset, uint64_t length,

--- a/tests/sxg_cert_chain_test.cc
+++ b/tests/sxg_cert_chain_test.cc
@@ -18,8 +18,8 @@
 
 #include <openssl/evp.h>
 #include <openssl/pem.h>
-
 #include <unistd.h>
+
 #include <fstream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Default behavior is changed between clang `8.0.0` to `9.0.0`.
So explicitly specifying `Regroup` will be the best way to make it works well on both clang8 and clang9.