### PR TITLE
simplify and optimize clang-format action

### DIFF
--- a/.github/workflows/clang-format-validation.yml
+++ b/.github/workflows/clang-format-validation.yml
@@ -1,5 +1,5 @@
 name: Validate code format with clang-format
-on: push
+on: [push, pull_request]
 jobs:
   validate:
     runs-on: ubuntu-18.04

--- a/.github/workflows/clang-format-validation.yml
+++ b/.github/workflows/clang-format-validation.yml
@@ -11,8 +11,8 @@ jobs:
         # https://apt.llvm.org/llvm.sh
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
-        sudo apt update
-        sudo apt install clang-format-9
+        sudo apt-get update
+        sudo apt-get install -y clang-format-9
 
     - name: Check diff
       run: |

--- a/.github/workflows/clang-format-validation.yml
+++ b/.github/workflows/clang-format-validation.yml
@@ -1,0 +1,21 @@
+name: Validate code format with clang-format
+on: push
+jobs:
+  validate:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install clang-format
+      run: |
+        # https://apt.llvm.org/llvm.sh
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+        sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+        sudo apt update
+        sudo apt install clang-format-9
+
+    - name: Check diff
+      run: |
+        git ls-files *.{c,h,hpp,cpp,cc} | xargs clang-format-9 -style=file -i
+        git diff --exit-code
+

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,9 +1,0 @@
-on: push
-name: Code Format Checker
-jobs:
-  lint:
-    name: Code Format Checker
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checker
-      uses: kumagi/clang-format-action@clang9-check-diff


### PR DESCRIPTION
This PR removes the dependency on https://github.com/kumagi/clang-format-action by

- stopping using docker as GitHub Actions itself offers runs-on option
- install (only) clang-format thorough apt instead of downloading whole clang+llvm

and pack everything into single and tiny yaml.

Also it turned out that [the check now runs in 30s](https://github.com/tomokinat/libsxg/commit/223afe264aad8c14095416606218d4756843d855/checks?check_suite_id=386307411) (time varies a lot among runs through), 7x faster than [current one](https://github.com/google/libsxg/commit/ce03fa07df8f92a77ab5ad46e70b0ea520a74c91/checks?check_suite_id=386257499).