### PR TITLE
Add CMake options for static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ set (LIBSXG_CORE_VERSION
      "${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}")
 set (LIBSXG_SOVERSION "${CMAKE_PROJECT_VERSION_MAJOR}")
 
+option (SXG_BUILD_SHARED "Build shared library" ON)
+option (SXG_BUILD_STATIC "Build static libirary" OFF)
+option (SXG_BUILD_EXECUTABLES "Build gensxg/gencertchain executables" ON)
+
 option (
   RUN_TEST
   "If false, build libsxg without building tests.\
@@ -53,8 +57,7 @@ set_property (DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY EP_UPDATE_DISCONNECTED 1)
 
 find_package (OpenSSL REQUIRED)
 
-add_library (
-  sxg SHARED
+set (SXG_SOURCES
   src/sxg_buffer.c
   src/sxg_buffer_debug.c
   src/sxg_cbor.c
@@ -67,44 +70,76 @@ add_library (
   src/sxg_sig.c
   src/sxg_signer_list.c)
 
-target_include_directories (sxg PRIVATE ${PROJECT_SOURCE_DIR}/include
-                                        ${OPENSSL_INCLUDE_DIR})
+if (SXG_BUILD_SHARED)
+  add_library (sxg SHARED ${SXG_SOURCES})
 
-target_link_libraries (sxg PRIVATE ${OPENSSL_LIBRARIES})
+  target_include_directories (sxg PRIVATE ${PROJECT_SOURCE_DIR}/include
+                                          ${OPENSSL_INCLUDE_DIR})
 
-add_executable (gensxg src/gensxg.c)
+  target_link_libraries (sxg PRIVATE ${OPENSSL_LIBRARIES})
+endif()
 
-target_include_directories (gensxg PRIVATE ${PROJECT_SOURCE_DIR}/include
-                                           ${OPENSSL_INCLUDE_DIR})
+if (SXG_BUILD_STATIC)
+  add_library (sxg_static STATIC ${SXG_SOURCES})
+  set_target_properties(sxg_static PROPERTIES OUTPUT_NAME sxg)
 
-target_link_libraries (gensxg PRIVATE ${OPENSSL_LIBRARIES} sxg)
-
-add_executable (gencertchain src/gencertchain.c)
-
-target_include_directories (gencertchain PRIVATE ${PROJECT_SOURCE_DIR}/include
+  target_include_directories (sxg_static PRIVATE ${PROJECT_SOURCE_DIR}/include
                                                  ${OPENSSL_INCLUDE_DIR})
 
-target_link_libraries (gencertchain PRIVATE ${OPENSSL_LIBRARIES} sxg)
+  target_link_libraries (sxg_static PRIVATE ${OPENSSL_LIBRARIES})
+endif ()
+
+if (SXG_BUILD_EXECUTABLES)
+  add_executable (gensxg src/gensxg.c)
+
+  target_include_directories (gensxg PRIVATE ${PROJECT_SOURCE_DIR}/include
+                                             ${OPENSSL_INCLUDE_DIR})
+
+  target_link_libraries (gensxg PRIVATE ${OPENSSL_LIBRARIES} sxg)
+
+  add_executable (gencertchain src/gencertchain.c)
+
+  target_include_directories (gencertchain PRIVATE ${PROJECT_SOURCE_DIR}/include
+                                                 ${OPENSSL_INCLUDE_DIR})
+
+  target_link_libraries (gencertchain PRIVATE ${OPENSSL_LIBRARIES} sxg)
+endif ()
 
 # ##############################################################################
 # Installing
 # ##############################################################################
 
-set_target_properties (
-  sxg PROPERTIES VERSION ${LIBSXG_CORE_VERSION} SOVERSION ${LIBSXG_SOVERSION})
+if (SXG_BUILD_SHARED)
+  set_target_properties (
+    sxg PROPERTIES VERSION ${LIBSXG_CORE_VERSION} SOVERSION ${LIBSXG_SOVERSION})
 
-set_target_properties (sxg PROPERTIES PUBLIC_HEADER "${HEADERS}")
-install (
-  TARGETS sxg
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library)
+  set_target_properties (sxg PROPERTIES PUBLIC_HEADER "${HEADERS}")
+  install (
+    TARGETS sxg
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library)
+endif ()
+if (SXG_BUILD_STATIC)
+  set_target_properties (
+    sxg_static PROPERTIES VERSION ${LIBSXG_CORE_VERSION} SOVERSION ${LIBSXG_SOVERSION})
+
+  set_target_properties (sxg_static PROPERTIES PUBLIC_HEADER "${HEADERS}")
+  install (
+    TARGETS sxg_static
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library)
+endif ()
+
 install (
   DIRECTORY ${CMAKE_SOURCE_DIR}/include/ PUBLIC_HEADER
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include
   FILES_MATCHING
   PATTERN "*.h*")
-install (TARGETS gensxg RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install (TARGETS gencertchain RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+if (SXG_BUILD_EXECUTABLES)
+  install (TARGETS gensxg RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install (TARGETS gencertchain RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif ()
 
 # ##############################################################################
 # Generate man files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,18 @@ option (SXG_BUILD_SHARED "Build shared library" ON)
 option (SXG_BUILD_STATIC "Build static libirary" OFF)
 option (SXG_BUILD_EXECUTABLES "Build gensxg/gencertchain executables" ON)
 
+if (NOT SXG_BUILD_SHARED AND NOT SXG_BUILD_STATIC)
+  message(
+    FATAL_ERROR
+    "One of SXG_BUILD_SHARED or SXG_BUILD_STATIC is required" )
+endif ()
+
+if (NOT SXG_BUILD_SHARED AND SXG_BUILD_EXECUTABLES)
+  message(
+    FATAL_ERROR
+    "Shared library required for gensxg/gencertchain executables" )
+endif ()
+
 option (
   RUN_TEST
   "If false, build libsxg without building tests.\
@@ -209,12 +221,22 @@ if (RUN_TEST)
                "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}")
   set (GTEST_INCLUDE
        "${PROJECT_BINARY_DIR}/third_party/gtest/googletest/include")
-  add_library (test_util SHARED tests/test_util.cc)
+  if (SXG_BUILD_SHARED)
+    add_library (test_util SHARED tests/test_util.cc)
+  else ()
+    add_library (test_util STATIC tests/test_util.cc)
+  endif ()
   target_include_directories (test_util PUBLIC ${PROJECT_SOURCE_DIR}/include
                                                ${GTEST_INCLUDE})
-  add_dependencies (test_util gtest libgtest libgtest_main sxg)
-  target_link_libraries (test_util INTERFACE libgtest libgtest_main pthread sxg
-                                             ${OPENSSL_LIBRARIES})
+  if (SXG_BUILD_SHARED)
+    add_dependencies (test_util gtest libgtest libgtest_main sxg)
+    target_link_libraries (test_util INTERFACE libgtest libgtest_main pthread sxg
+                                              ${OPENSSL_LIBRARIES})
+  else ()
+    add_dependencies (test_util gtest libgtest libgtest_main sxg_static)
+    target_link_libraries (test_util INTERFACE libgtest libgtest_main pthread sxg_static
+                                              ${OPENSSL_LIBRARIES})
+  endif ()
 endif ()
 
 set (SANITIZER_OPTIONS "-fsanitize=address,leak,undefined")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ set (LIBSXG_SOVERSION "${CMAKE_PROJECT_VERSION_MAJOR}")
 
 option (SXG_BUILD_SHARED "Build shared library" ON)
 option (SXG_BUILD_STATIC "Build static libirary" OFF)
-option (SXG_BUILD_EXECUTABLES "Build gensxg/gencertchain executables" ON)
+include (CMakeDependentOption)
+cmake_dependent_option (SXG_BUILD_EXECUTABLES "Build gensxg/gencertchain executables" ON
+                        SXG_BUILD_SHARED OFF)
 
 if (NOT SXG_BUILD_SHARED AND NOT SXG_BUILD_STATIC)
   message(


### PR DESCRIPTION
Add an option (-DSXG_BUILD_STATIC, default off) to build a static library (libsxg.a) with make target sxg_static. Also added an option for existing shared library build(-DSXG_BUILD_SHARED, default on) and gensxg/gencertchain exectutables (-DSXG_BUILD_EXECUTABLES, default on) so that they can be disabled easilty. Default behavior should not be changed.

https://github.com/google/libsxg/issues/65