### PR TITLE
Use EVP_EncodeBlock instead of BIO methods for BoringSSL compatibility

### DIFF
--- a/src/sxg_codec.c
+++ b/src/sxg_codec.c
@@ -47,7 +47,7 @@ bool sxg_calc_sha384(const sxg_buffer_t* src, sxg_buffer_t* dst) {
 bool sxg_base64encode_bytes(const uint8_t* src, size_t length,
                             sxg_buffer_t* dst) {
   /* 3-byte blocks to 4-byte */
-  const EVP_ENCODE_BLOCK_T out_length = 4*((length + 2) / 3);
+  const EVP_ENCODE_BLOCK_T out_length = 4 * ((length + 2) / 3);
   return sxg_buffer_resize(out_length, dst) &&
          EVP_EncodeBlock(dst->data, src, length) == out_length;
 }

--- a/src/sxg_codec.c
+++ b/src/sxg_codec.c
@@ -46,10 +46,11 @@ bool sxg_calc_sha384(const sxg_buffer_t* src, sxg_buffer_t* dst) {
 
 bool sxg_base64encode_bytes(const uint8_t* src, size_t length,
                             sxg_buffer_t* dst) {
+  const size_t offset = dst->size;
   /* 3-byte blocks to 4-byte */
   const EVP_ENCODE_BLOCK_T out_length = 4 * ((length + 2) / 3);
-  return sxg_buffer_resize(out_length, dst) &&
-         EVP_EncodeBlock(dst->data, src, length) == out_length;
+  return sxg_buffer_resize(offset + out_length, dst) &&
+         EVP_EncodeBlock(dst->data + offset, src, length) == out_length;
 }
 
 bool sxg_base64encode(const sxg_buffer_t* src, sxg_buffer_t* dst) {

--- a/src/sxg_codec.c
+++ b/src/sxg_codec.c
@@ -47,8 +47,10 @@ bool sxg_calc_sha384(const sxg_buffer_t* src, sxg_buffer_t* dst) {
 bool sxg_base64encode_bytes(const uint8_t* src, size_t length,
                             sxg_buffer_t* dst) {
   const size_t offset = dst->size;
-  /* 3-byte blocks to 4-byte */
+  // 3-byte blocks to 4-byte, rounded up
   const EVP_ENCODE_BLOCK_T out_length = 4 * ((length + 2) / 3);
+  if (out_length < length) return false;
+
   return sxg_buffer_resize(offset + out_length, dst) &&
          EVP_EncodeBlock(dst->data + offset, src, length) == out_length;
 }


### PR DESCRIPTION
BIO_f_base64 is deprecated in BoringSSL, and EVP_EncodeBlock/EVP_DecodeBlock is suggested as an alternative.

Note that the return type of EVP_EncodeBlock is size_t in BoringSSL and int in OpenSSL