### PR TITLE
remove ct.h

### DIFF
--- a/include/libsxg/sxg_cert_chain.h
+++ b/include/libsxg/sxg_cert_chain.h
@@ -17,7 +17,6 @@
 #ifndef LIBSXG_SXG_CERT_CHAIN_H_
 #define LIBSXG_SXG_CERT_CHAIN_H_
 
-#include <openssl/ct.h>
 #include <openssl/ocsp.h>
 #include <openssl/x509.h>
 #include <stdbool.h>


### PR DESCRIPTION
ct.h isn't included by BoringSSL. Since it doesn't appear to be needed, just remove it.