### PR TITLE
Fix build for OS X

### DIFF
--- a/include/libsxg/internal/sxg_cbor.h
+++ b/include/libsxg/internal/sxg_cbor.h
@@ -33,7 +33,7 @@ bool sxg_write_utf8_cbor_header(uint64_t length, sxg_buffer_t* target);
 
 // Appends the header for a map (visible for testing).
 // Returns true on success.
-bool sxg_write_map_cbor_header(size_t size, sxg_buffer_t* target);
+bool sxg_write_map_cbor_header(uint64_t size, sxg_buffer_t* target);
 
 // Appends the initial bytes for a array.
 // Returns true on success.

--- a/src/sxg_cbor.c
+++ b/src/sxg_cbor.c
@@ -50,7 +50,7 @@ bool sxg_write_utf8_cbor_header(uint64_t length, sxg_buffer_t* target) {
   return write_initial_bytes(0x60, length, target);
 }
 
-bool sxg_write_map_cbor_header(size_t size, sxg_buffer_t* target) {
+bool sxg_write_map_cbor_header(uint64_t size, sxg_buffer_t* target) {
   return write_initial_bytes(0xa0, size, target);
 }
 

--- a/src/sxg_cbor.c
+++ b/src/sxg_cbor.c
@@ -50,7 +50,7 @@ bool sxg_write_utf8_cbor_header(uint64_t length, sxg_buffer_t* target) {
   return write_initial_bytes(0x60, length, target);
 }
 
-bool sxg_write_map_cbor_header(uint64_t size, sxg_buffer_t* target) {
+bool sxg_write_map_cbor_header(size_t size, sxg_buffer_t* target) {
   return write_initial_bytes(0xa0, size, target);
 }
 


### PR DESCRIPTION
Consistently use size_t across header and implementation file.

Signed-off-by: Raul Gutierrez Segales <rgs@pinterest.com>