### PR TITLE
Fix sxg_sig_test to allow variable-size sig.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,7 @@ function (configure_test test_name)
 endfunction ()
 
 if (RUN_TEST)
-  # configure_test (nfail_malloc_test)
+  configure_test (nfail_malloc_test)
   configure_test (sxg_buffer_test)
   configure_test (sxg_cbor_test)
   if (SXG_WITH_CERT_CHAIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ if (RUN_TEST)
   endif ()
   target_include_directories (test_util PUBLIC ${PROJECT_BINARY_DIR}/include
                                                ${PROJECT_SOURCE_DIR}/include
+                                               ${OPENSSL_INCLUDE_DIR}
                                                ${GTEST_INCLUDE})
   if (SXG_BUILD_SHARED)
     add_dependencies (test_util gtest libgtest libgtest_main sxg)
@@ -280,7 +281,7 @@ function (configure_test test_name)
 endfunction ()
 
 if (RUN_TEST)
-  configure_test (nfail_malloc_test)
+  # configure_test (nfail_malloc_test)
   configure_test (sxg_buffer_test)
   configure_test (sxg_cbor_test)
   if (SXG_WITH_CERT_CHAIN)

--- a/include/libsxg/internal/sxg_codec.h
+++ b/include/libsxg/internal/sxg_codec.h
@@ -51,6 +51,12 @@ bool sxg_calculate_cert_sha256(X509* cert, sxg_buffer_t* dst);
 bool sxg_evp_sign(EVP_PKEY* private_key, const sxg_buffer_t* src,
                   sxg_buffer_t* dst);
 
+#ifdef OPENSSL_IS_BORINGSSL
+#define EVP_ENCODE_BLOCK_T size_t
+#else
+#define EVP_ENCODE_BLOCK_T int
+#endif
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/src/sxg_codec.c
+++ b/src/sxg_codec.c
@@ -38,12 +38,6 @@ bool sxg_calc_sha384(const sxg_buffer_t* src, sxg_buffer_t* dst) {
          SHA384(src->data, src->size, dst->data);
 }
 
-#ifdef OPENSSL_IS_BORINGSSL
-#define EVP_ENCODE_BLOCK_T size_t
-#else
-#define EVP_ENCODE_BLOCK_T int
-#endif
-
 bool sxg_base64encode_bytes(const uint8_t* src, size_t length,
                             sxg_buffer_t* dst) {
   const size_t offset = dst->size;

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -130,19 +130,18 @@ TEST(SxgSig, MakeSignature) {
   // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#name-signature-validity
   sxg_buffer_t expected_message = sxg_empty_buffer();
   const uint8_t expected_message_buf[] =
-                  "                                "
-                  "                                "
-                  "HTTP Exchange 1 b3\0 "  // preamble
-                  "\x5a\xba\x53\x1e\xb9\xd1\xf4\x8f\x42\x8f\xe7\x22\xcd\x74\xe8"
-                  "\xcc\x46\x41\xf8\x19\xe3\x40\xa9\x11\x7b\xc9\x0a\x82\x67\xb8"
-                  "\x88\xb5"  // cert-sha256
-                  "\0\0\0\0\0\0\0\x1ehttps://cert.test/validity.msg"
-                  // validity-url
-                  "\0\0\0\0\0\0\0\0"  // date
-                  "\0\0\0\0\0\0\0\0"  // expires
-                  "\0\0\0\0\0\0\0\x11https://sxg.test/"  // requestUrl
-                  "\0\0\0\0\0\0\0\x0c"
-                  "dummy_header"; // responseHeaders
+      "                                "
+      "                                "
+      "HTTP Exchange 1 b3\0 "  // preamble
+      "\x5a\xba\x53\x1e\xb9\xd1\xf4\x8f\x42\x8f\xe7\x22\xcd\x74\xe8"
+      "\xcc\x46\x41\xf8\x19\xe3\x40\xa9\x11\x7b\xc9\x0a\x82\x67\xb8"
+      "\x88\xb5"                                          // cert-sha256
+      "\0\0\0\0\0\0\0\x1ehttps://cert.test/validity.msg"  // validity-url
+      "\0\0\0\0\0\0\0\0"                                  // date
+      "\0\0\0\0\0\0\0\0"                                  // expires
+      "\0\0\0\0\0\0\0\x11https://sxg.test/"               // requestUrl
+      "\0\0\0\0\0\0\0\x0c"
+      "dummy_header";  // responseHeaders
   sxg_write_bytes(expected_message_buf,
                   sizeof(expected_message_buf) - 1 /* terminating NUL */,
                   &expected_message);

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -16,9 +16,10 @@
 
 #include "libsxg/internal/sxg_sig.h"
 
+#include <openssl/x509.h>
+
 #include <cstdio>
 #include <string>
-#include <openssl/x509.h>
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_codec.h"
@@ -30,11 +31,13 @@ namespace {
 // Splices sig value out of buffer and into signature.
 void ExtractSignature(sxg_buffer_t* buffer, sxg_buffer_t* signature) {
   static const char sigKey[] = "sig=";
-  uint8_t* begin = (uint8_t*)strstr((char*)buffer->data, sigKey) + sizeof(sigKey);
+  uint8_t* begin =
+      (uint8_t*)strstr((char*)buffer->data, sigKey) + sizeof(sigKey);
   EXPECT_EQ('*', *(begin - 1));
 
-  uint8_t *end = begin;
-  while (*++end != '*');
+  uint8_t* end = begin;
+  while (*++end != '*')
+    ;
   EXPECT_EQ('*', *end);
 
   EXPECT_TRUE(sxg_buffer_resize(end - begin, signature));
@@ -57,14 +60,14 @@ void sxg_base64decode(const sxg_buffer_t* src, sxg_buffer_t* dst) {
   EVP_ENCODE_CTX* ctx = EVP_ENCODE_CTX_new();
   EVP_DecodeInit(ctx);
   EVP_ENCODE_BLOCK_T out_length;
-  if (EVP_DecodeUpdate(ctx, dst->data + offset, &out_length,
-                       src->data, src->size) == -1) {
+  if (EVP_DecodeUpdate(ctx, dst->data + offset, &out_length, src->data,
+                       src->size) == -1) {
     EVP_ENCODE_CTX_free(ctx);
     FAIL();
   }
   EVP_ENCODE_BLOCK_T out_length2;
-  if (EVP_DecodeFinal(ctx, dst->data + offset + out_length, &out_length2)
-          == -1) {
+  if (EVP_DecodeFinal(ctx, dst->data + offset + out_length, &out_length2) ==
+      -1) {
     EVP_ENCODE_CTX_free(ctx);
     FAIL();
   }
@@ -85,8 +88,8 @@ void sxg_evp_verify(EVP_PKEY* private_key, const sxg_buffer_t& message,
   // https://www.openssl.org/docs/manmaster/man3/EVP_DigestVerifyInit.html
   ASSERT_TRUE(ctx != NULL);
   ASSERT_EQ(EVP_DigestVerifyInit(ctx, NULL, digest_func, NULL, private_key), 1);
-  ASSERT_EQ(EVP_DigestVerify(ctx, signature.data, signature.size,
-                             message.data, message.size),
+  ASSERT_EQ(EVP_DigestVerify(ctx, signature.data, signature.size, message.data,
+                             message.size),
             1);
 
   EVP_MD_CTX_free(ctx);

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -129,21 +129,23 @@ TEST(SxgSig, MakeSignature) {
 
   // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#name-signature-validity
   sxg_buffer_t expected_message = sxg_empty_buffer();
-  sxg_write_bytes((const uint8_t*)
+  const uint8_t expected_message_buf[] =
                   "                                "
-                  "                                "  // 64 bytes
-                  "HTTP Exchange 1 b3\0 "  // preamble, 20 bytes
+                  "                                "
+                  "HTTP Exchange 1 b3\0 "  // preamble
                   "\x5a\xba\x53\x1e\xb9\xd1\xf4\x8f\x42\x8f\xe7\x22\xcd\x74\xe8"
                   "\xcc\x46\x41\xf8\x19\xe3\x40\xa9\x11\x7b\xc9\x0a\x82\x67\xb8"
-                  "\x88\xb5"  // cert-sha256, 32 bytes
+                  "\x88\xb5"  // cert-sha256
                   "\0\0\0\0\0\0\0\x1ehttps://cert.test/validity.msg"
-                  // validity-url, 38 bytes
-                  "\0\0\0\0\0\0\0\0"  // date, 8 bytes
-                  "\0\0\0\0\0\0\0\0"  // expires, 8 bytes
-                  "\0\0\0\0\0\0\0\x11https://sxg.test/"  // requestUrl, 25 bytes
+                  // validity-url
+                  "\0\0\0\0\0\0\0\0"  // date
+                  "\0\0\0\0\0\0\0\0"  // expires
+                  "\0\0\0\0\0\0\0\x11https://sxg.test/"  // requestUrl
                   "\0\0\0\0\0\0\0\x0c"
-                  "dummy_header", // responseHeaders, 20 bytes
-                  64+20+32+38+8+8+25+20, &expected_message);
+                  "dummy_header"; // responseHeaders
+  sxg_write_bytes(expected_message_buf,
+                  sizeof(expected_message_buf) - 1 /* terminating NUL */,
+                  &expected_message);
 
   {
     SCOPED_TRACE("signature: " + sxg_test::BufferToString(signature));

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <string>
+#include <openssl/x509.h>
 
 #include "gtest/gtest.h"
 #include "libsxg/internal/sxg_codec.h"
@@ -26,13 +27,69 @@
 
 namespace {
 
-void FillSignature(sxg_buffer_t* buffer) {
+// Splices sig value out of buffer and into signature.
+void ExtractSignature(sxg_buffer_t* buffer, sxg_buffer_t* signature) {
   static const char sigKey[] = "sig=";
-  char* point = strstr((char*)buffer->data, sigKey) + sizeof(sigKey) - 1;
-  EXPECT_EQ('*', *point++);
-  while (*point != '*') {
-    *point++ = '%';
+  uint8_t* begin = (uint8_t*)strstr((char*)buffer->data, sigKey) + sizeof(sigKey);
+  EXPECT_EQ('*', *(begin - 1));
+
+  uint8_t *end = begin;
+  while (*++end != '*');
+  EXPECT_EQ('*', *end);
+
+  EXPECT_TRUE(sxg_buffer_resize(end - begin, signature));
+  memcpy(signature->data, begin, end - begin);
+
+  memmove(begin, end, (buffer->data + buffer->size) - end);
+  EXPECT_TRUE(sxg_buffer_resize(buffer->size - (end - begin), buffer));
+}
+
+void sxg_base64decode(const sxg_buffer_t* src, sxg_buffer_t* dst) {
+  const size_t offset = dst->size;
+  // 4-byte blocks to 3-byte, assuming none are padding chars; we'll adjust at
+  // the end.
+  const EVP_ENCODE_BLOCK_T estimated_out_length = 3 * (src->size / 4);
+
+  // EVP_DecodeBlock doesn't support padding chars, so we use the long form.
+  if (!sxg_buffer_resize(offset + estimated_out_length, dst)) {
+    FAIL();
   }
+  EVP_ENCODE_CTX* ctx = EVP_ENCODE_CTX_new();
+  EVP_DecodeInit(ctx);
+  EVP_ENCODE_BLOCK_T out_length;
+  if (EVP_DecodeUpdate(ctx, dst->data + offset, &out_length,
+                       src->data, src->size) == -1) {
+    EVP_ENCODE_CTX_free(ctx);
+    FAIL();
+  }
+  EVP_ENCODE_BLOCK_T out_length2;
+  if (EVP_DecodeFinal(ctx, dst->data + offset + out_length, &out_length2)
+          == -1) {
+    EVP_ENCODE_CTX_free(ctx);
+    FAIL();
+  }
+  if (!sxg_buffer_resize(offset + out_length + out_length2, dst)) {
+    EVP_ENCODE_CTX_free(ctx);
+    FAIL();
+  }
+  EVP_ENCODE_CTX_free(ctx);
+}
+
+void sxg_evp_verify(EVP_PKEY* private_key, const sxg_buffer_t& message,
+                    const sxg_buffer_t& signature) {
+  EVP_MD_CTX* const ctx = EVP_MD_CTX_new();
+  const EVP_MD* digest_func = EVP_sha256();
+
+  // EVP_DigestVerify functions return 1 on success; any other value indicates
+  // failure.
+  // https://www.openssl.org/docs/manmaster/man3/EVP_DigestVerifyInit.html
+  ASSERT_TRUE(ctx != NULL);
+  ASSERT_EQ(EVP_DigestVerifyInit(ctx, NULL, digest_func, NULL, private_key), 1);
+  ASSERT_EQ(EVP_DigestVerify(ctx, signature.data, signature.size,
+                             message.data, message.size),
+            1);
+
+  EVP_MD_CTX_free(ctx);
 }
 
 TEST(SxgSig, ConstructAndRelease) {
@@ -51,9 +108,7 @@ TEST(SxgSig, MakeSignature) {
       "testname;cert-sha256=*WrpTHrnR9I9Cj+cizXTozEZB+BnjQKkRe8kKgme4iLU=*;"
       "cert-url=\"https://cert.test/"
       "cert.cbor\";date=0;expires=0;integrity=\"digest/"
-      "mi-sha256-03\";sig=*%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
-      "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%*;validity-url=\"https://"
-      "cert.test/validity.msg\"");
+      "mi-sha256-03\";sig=**;validity-url=\"https://cert.test/validity.msg\"");
 
   EXPECT_TRUE(sxg_sig_set_name("testname", &sig));
   EXPECT_TRUE(sxg_sig_set_cert_sha256(cert, &sig));
@@ -62,8 +117,36 @@ TEST(SxgSig, MakeSignature) {
   EXPECT_TRUE(sxg_sig_set_validity_url("https://cert.test/validity.msg", &sig));
   EXPECT_TRUE(sxg_sig_generate_sig("https://sxg.test/", &header, pkey, &sig));
   EXPECT_TRUE(sxg_write_signature(&sig, &output));
-  FillSignature(&output);
+
+  sxg_buffer_t signature = sxg_empty_buffer();
+  ExtractSignature(&output, &signature);
   EXPECT_EQ(expected, sxg_test::BufferToString(output));
+
+  // https://wicg.github.io/webpackage/draft-yasskin-httpbis-origin-signed-exchanges-impl.html#name-signature-validity
+  sxg_buffer_t expected_message = sxg_empty_buffer();
+  sxg_write_bytes((const uint8_t*)
+                  "                                "
+                  "                                "  // 64 bytes
+                  "HTTP Exchange 1 b3\0 "  // preamble, 20 bytes
+                  "\x5a\xba\x53\x1e\xb9\xd1\xf4\x8f\x42\x8f\xe7\x22\xcd\x74\xe8"
+                  "\xcc\x46\x41\xf8\x19\xe3\x40\xa9\x11\x7b\xc9\x0a\x82\x67\xb8"
+                  "\x88\xb5"  // cert-sha256, 32 bytes
+                  "\0\0\0\0\0\0\0\x1ehttps://cert.test/validity.msg"
+                  // validity-url, 38 bytes
+                  "\0\0\0\0\0\0\0\0"  // date, 8 bytes
+                  "\0\0\0\0\0\0\0\0"  // expires, 8 bytes
+                  "\0\0\0\0\0\0\0\x11https://sxg.test/"  // requestUrl, 25 bytes
+                  "\0\0\0\0\0\0\0\x0c"
+                  "dummy_header", // responseHeaders, 20 bytes
+                  64+20+32+38+8+8+25+20, &expected_message);
+
+  {
+    SCOPED_TRACE("signature: " + sxg_test::BufferToString(signature));
+    sxg_buffer_t signature_decoded = sxg_empty_buffer();
+    EXPECT_NO_FATAL_FAILURE(sxg_base64decode(&signature, &signature_decoded));
+    EXPECT_NO_FATAL_FAILURE(
+        sxg_evp_verify(pkey, expected_message, signature_decoded));
+  }
 
   EVP_PKEY_free(pkey);
   X509_free(cert);

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -103,12 +103,6 @@ TEST(SxgSig, ConstructAndRelease) {
 }
 
 TEST(SxgSig, MakeSignature) {
-#ifdef OPENSSL_IS_BORINGSSL
-  std::cout << "hello from boringssl" << std::endl;
-#else
-  std::cout << "hello from openssl" << std::endl;
-#endif
-
   sxg_sig_t sig = sxg_empty_sig();
   X509* cert = sxg_test::LoadX509Cert("testdata/cert256.pem");
   sxg_buffer_t header = sxg_empty_buffer();

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -58,10 +58,9 @@ void sxg_base64decode(const sxg_buffer_t* src, sxg_buffer_t* dst) {
 
 #ifdef OPENSSL_IS_BORINGSSL
   size_t out_length;
-  ASSERT_EQ(
-      EVP_DecodeBase64(dst->data + offset, &out_length, estimated_out_length,
-                       src->data, src->size),
-      1);
+  ASSERT_EQ(EVP_DecodeBase64(dst->data + offset, &out_length,
+                             estimated_out_length, src->data, src->size),
+            1);
   ASSERT_TRUE(sxg_buffer_resize(offset + out_length, dst));
 #else
   // EVP_DecodeBlock doesn't support padding chars, so we use the long form.

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -56,9 +56,7 @@ void sxg_base64decode(const sxg_buffer_t* src, sxg_buffer_t* dst) {
   const EVP_ENCODE_BLOCK_T estimated_out_length = 3 * (src->size / 4);
 
   // EVP_DecodeBlock doesn't support padding chars, so we use the long form.
-  if (!sxg_buffer_resize(offset + estimated_out_length, dst)) {
-    FAIL();
-  }
+  ASSERT_TRUE(sxg_buffer_resize(offset + estimated_out_length, dst));
   EVP_ENCODE_CTX* ctx = EVP_ENCODE_CTX_new();
   EVP_DecodeInit(ctx);
   EVP_ENCODE_BLOCK_T out_length;

--- a/tests/sxg_sig_test.cc
+++ b/tests/sxg_sig_test.cc
@@ -64,11 +64,11 @@ void sxg_base64decode(const sxg_buffer_t* src, sxg_buffer_t* dst) {
   EVP_ENCODE_CTX* ctx = EVP_ENCODE_CTX_new();
 #endif
   EVP_DecodeInit(ctx);
-  EVP_ENCODE_BLOCK_T out_length;
+  int out_length;
   ASSERT_NE(EVP_DecodeUpdate(ctx, dst->data + offset, &out_length, src->data,
                              src->size),
             -1);
-  EVP_ENCODE_BLOCK_T out_length2;
+  int out_length2;
   ASSERT_NE(EVP_DecodeFinal(ctx, dst->data + offset + out_length, &out_length2),
             -1);
   ASSERT_TRUE(sxg_buffer_resize(offset + out_length + out_length2, dst));


### PR DESCRIPTION
The ECDSA signature is a DER-encoded pair of integers, which results in
variable length. Change the assertion to remove the signature rather than
filling with % chars, so that it's resilient to this.

In addition, add an assertion that the signature is correct, by hard-coding an
expected signed message and then making all the necessary OpenSSL calls.

This was tested with

```bash
$ (attempts=0; display_attempts () { echo Attempts: $attempts; }; trap display_attempts INT && make sxg_sig_test && while 
./sxg_sig_test; do attempts=$(($attempts+1)); done)
...
^CAttempts: 4652
```

Fixes #76.

/cc @cpapazian @rgs1 Can you verify this works against BoringSSL?