### PR TITLE
handle error of OCSP_sendreq_nbio

### DIFF
--- a/src/sxg_cert_chain.c
+++ b/src/sxg_cert_chain.c
@@ -153,17 +153,16 @@ bool sxg_execute_ocsp_request(BIO* io, const char* path, OCSP_CERTID* id,
   bool success = OCSP_request_add0_id(req, id) &&
                  OCSP_REQ_CTX_set1_req(octx, req) && wait_fd(fd, false, true);
   while (success) {
-    switch (OCSP_sendreq_nbio(dst, octx) {
+    switch (OCSP_sendreq_nbio(dst, octx)) {
       case -1:
+        success =
+            success && wait_fd(fd, BIO_should_read(io), BIO_should_write(io));
         continue;
       case 0:
         success = false;
-        break;
       case 1:
-        success =
-            success && wait_fd(fd, BIO_should_read(io), BIO_should_write(io));
-        break;
     }
+    break;
   }
 
   OCSP_REQUEST_free(req);


### PR DESCRIPTION
as [document](https://www.openssl.org/docs/man1.1.0/man3/OCSP_sendreq_nbio.html) says, `OCSP_sendreq_nbio` returns 3 values.

```
-1: retry.
0: error.
1: success
```

Then this logic should handle error returned value to propagate the context to the return value.