### PR TITLE
Fix mount point for GitHub workflows.

### DIFF
--- a/.github/workflows/make-debs.yml
+++ b/.github/workflows/make-debs.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           mkdir -p $(pwd)/${{ matrix.names.image_name }}
           docker build --build-arg base_image=${{ matrix.names.base_image }} -t ${{ matrix.names.image_name }} -f packaging/Dockerfile .
-          docker run --rm --mount "type=bind,source=$(pwd)/${{ matrix.names.image_name }},target=/libsxg/output" ${{ matrix.names.image_name }}
+          docker run --rm --mount "type=bind,source=$(pwd)/${{ matrix.names.image_name }},target=/packaging/output" ${{ matrix.names.image_name }}
           zip -r libsxg-${{ matrix.names.image_name }}.zip $(pwd)/${{ matrix.names.image_name }}
 
       - name: Upload artifacts

--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           mkdir -p $(pwd)/${{ matrix.names.image_name }}
           docker build --build-arg base_image=${{ matrix.names.base_image }} -t ${{ matrix.names.image_name }} -f packaging/Dockerfile .
-          docker run --rm --mount "type=bind,source=$(pwd)/${{ matrix.names.image_name }},target=/libsxg/output" ${{ matrix.names.image_name }}
+          docker run --rm --mount "type=bind,source=$(pwd)/${{ matrix.names.image_name }},target=/packaging/output" ${{ matrix.names.image_name }}
           zip -r libsxg-${{ matrix.names.image_name }}.zip $(pwd)/${{ matrix.names.image_name }}
 
       - name: Upload to release


### PR DESCRIPTION
Change mount pounts to /packaging/output to match what
packaging/{Dockerfile,build_deb} do. This should fix the zip files attached to
push actions and releases so that they are no longer empty.