### PR TITLE
Increase cmake minimum version from 3.0 to 3.13.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,10 @@ if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE "Debug")
 endif ()
 
-if (RUN_TEST)
-  # `target_link_options` used in fuzzing test requires 3.13
-  cmake_minimum_required (VERSION 3.13)
-else ()
-  cmake_minimum_required (VERSION 3.0)
-endif ()
+# When RUN_TEST is enabled, `target_link_options` used in fuzzing test requires 3.13.
+# When RUN_TEST is disabled, I'm not sure what minimum version is required, but
+# anecdotally it's higher than 3.0.
+cmake_minimum_required (VERSION 3.13)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++11 -fPIC")
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -std=c99 -fPIC -D_POSIX_C_SOURCE=200112L")


### PR DESCRIPTION
It was already at 3.13 for RUN_TEST=on. Now it's so for RUN_TEST=off, too,
based on anecdotal evidence. It's possible the actual minimum is somewhere in
between.

Fixes #93. /cc @cpapazian 