### PR TITLE
Add support for older versions of CMake.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       script:
         - install -d build
         - cd build
-        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC ..
+        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DRUN_TEST=off ..
         - make VERBOSE=1
         - ctest --output-on-failure
     - name: 'boringssl'
@@ -51,6 +51,6 @@ matrix:
         - go version
         - install -d build
         - cd build
-        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DSXG_BUILD_SHARED=off -DSXG_BUILD_STATIC=on -DRUN_TEST=on -DSXG_WITH_CERT_CHAIN=off -DOPENSSL_CRYPTO_LIBRARY=${BORINGSSL_ROOT}/build/crypto/libcrypto.a -DOPENSSL_ROOT_DIR=${BORINGSSL_ROOT} -DOPENSSL_INCLUDE_DIR=${BORINGSSL_ROOT}/include ..
+        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DSXG_BUILD_SHARED=off -DSXG_BUILD_STATIC=on -DRUN_TEST=off -DSXG_WITH_CERT_CHAIN=off -DOPENSSL_CRYPTO_LIBRARY=${BORINGSSL_ROOT}/build/crypto/libcrypto.a -DOPENSSL_ROOT_DIR=${BORINGSSL_ROOT} -DOPENSSL_INCLUDE_DIR=${BORINGSSL_ROOT}/include ..
         - make VERBOSE=1
         - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,37 @@ matrix:
         - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC ..
         - make VERBOSE=1
         - ctest --output-on-failure
+    - name: 'openssl-cmake_old'
+      os: linux
+      compiler: clang
+      before_script:
+        - source ./.travis/install_cmake_old.sh
+        - source ./.travis/install_openssl.sh
+      script:
+        - install -d build
+        - cd build
+        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC ..
+        - make VERBOSE=1
+        - ctest --output-on-failure
     - name: 'boringssl'
       os: linux
       compiler: clang
       before_script:
         - source ./.travis/install_cmake.sh
+        - source ./.travis/install_go.sh
+        - source ./.travis/install_boringssl.sh
+      script:
+        - go version
+        - install -d build
+        - cd build
+        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DSXG_BUILD_SHARED=off -DSXG_BUILD_STATIC=on -DRUN_TEST=on -DSXG_WITH_CERT_CHAIN=off -DOPENSSL_CRYPTO_LIBRARY=${BORINGSSL_ROOT}/build/crypto/libcrypto.a -DOPENSSL_ROOT_DIR=${BORINGSSL_ROOT} -DOPENSSL_INCLUDE_DIR=${BORINGSSL_ROOT}/include ..
+        - make VERBOSE=1
+        - ctest --output-on-failure
+    - name: 'boringssl-cmake_old'
+      os: linux
+      compiler: clang
+      before_script:
+        - source ./.travis/install_cmake_old.sh
         - source ./.travis/install_go.sh
         - source ./.travis/install_boringssl.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       script:
         - install -d build
         - cd build
-        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DRUN_TEST=off ..
+        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DRUN_TEST=off -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_BINDIR=bin ..
         - make VERBOSE=1
         - ctest --output-on-failure
     - name: 'boringssl'
@@ -51,6 +51,6 @@ matrix:
         - go version
         - install -d build
         - cd build
-        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DSXG_BUILD_SHARED=off -DSXG_BUILD_STATIC=on -DRUN_TEST=off -DSXG_WITH_CERT_CHAIN=off -DOPENSSL_CRYPTO_LIBRARY=${BORINGSSL_ROOT}/build/crypto/libcrypto.a -DOPENSSL_ROOT_DIR=${BORINGSSL_ROOT} -DOPENSSL_INCLUDE_DIR=${BORINGSSL_ROOT}/include ..
+        - cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DSXG_BUILD_SHARED=off -DSXG_BUILD_STATIC=on -DRUN_TEST=off -DSXG_WITH_CERT_CHAIN=off -DOPENSSL_CRYPTO_LIBRARY=${BORINGSSL_ROOT}/build/crypto/libcrypto.a -DOPENSSL_ROOT_DIR=${BORINGSSL_ROOT} -DOPENSSL_INCLUDE_DIR=${BORINGSSL_ROOT}/include -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_BINDIR=bin ..
         - make VERBOSE=1
         - ctest --output-on-failure

--- a/.travis/install_cmake_old.sh
+++ b/.travis/install_cmake_old.sh
@@ -2,10 +2,10 @@
 
 DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
 mkdir ${DEPS_DIR} && pushd ${DEPS_DIR}
-CMAKE="cmake-3.15.2-Linux-x86_64"
+CMAKE="cmake-3.1.0-Linux-x86_64"
 CMAKE_TAR="${CMAKE}.tar.gz"
-travis_retry wget --no-check-certificate "https://github.com/Kitware/CMake/releases/download/v3.15.2/${CMAKE_TAR}"
-echo "bf433a0e0674cfb358b127e7120dccaa ${CMAKE_TAR}" > cmake_md5.txt
+travis_retry wget --no-check-certificate "https://github.com/Kitware/CMake/releases/download/v3.1.0/${CMAKE_TAR}"
+echo "9fb313d98eac5eedc654a3164d33becd ${CMAKE_TAR}" > cmake_md5.txt
 md5sum -c cmake_md5.txt
 tar -xf "${CMAKE_TAR}"
 mv "${CMAKE}" cmake-install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,12 @@ endif ()
 
 # When RUN_TEST is enabled, `target_link_options` used in fuzzing test requires 3.13.
 # When RUN_TEST is disabled, I'm not sure what minimum version is required, but
-# anecdotally it's higher than 3.0.
-cmake_minimum_required (VERSION 3.13)
+# it worked when tested at 3.1.
+if (RUN_TEST)
+  cmake_minimum_required (VERSION 3.13)
+else ()
+  cmake_minimum_required (VERSION 3.1)
+endif ()
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++11 -fPIC")
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -std=c99 -fPIC -D_POSIX_C_SOURCE=200112L")

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Simple cmake project.
 ```ShellSession
 $ mkdir build
 $ cd build
-$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=path/to/usr
+$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=path/to/usr -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_BINDIR=bin
 $ make sxg
 $ sudo make install
 ```


### PR DESCRIPTION
Change cmake_minimum_required to 3.1 (earliest I could easily test) and update
the README to specify CMAKE_INSTALL_LIBDIR=lib and CMAKE_INSTALL_BINDIR=bin,
which it seems only became the default somewhere between CMake 3.11 and 3.15
inclusive.

/cc @cpapazian 