### PR TITLE
Fix gtest branch in CMakefile.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ if (RUN_TEST)
   ExternalProject_Add (
     gtest
     GIT_REPOSITORY https://github.com/google/googletest
-    GIT_TAG master
+    GIT_TAG main
     SOURCE_DIR ${PROJECT_BINARY_DIR}/third_party/gtest
     BINARY_DIR ${PROJECT_BINARY_DIR}/gtest
     INSTALL_COMMAND "")


### PR DESCRIPTION
Googletest repository's main tag has changed name to `main`. I'm not sure when it had been changed. 
In default CMakefile has described this as `master`. So it failed to make with following logs. I fixed tag's name.

```
% make
Scanning dependencies of target gtest
[  1%] Creating directories for 'gtest'
[  3%] Performing download step (git clone) for 'gtest'
Cloning into 'gtest'...
fatal: invalid reference: master
CMake Error at /Users/yugo-horie/libsxg/build/gtest-prefix/tmp/gtest-gitclone.cmake:40 (message):
  Failed to checkout tag: 'master'


make[2]: *** [gtest-prefix/src/gtest-stamp/gtest-download] Error 1
make[1]: *** [CMakeFiles/gtest.dir/all] Error 2
make: *** [all] Error 2
```